### PR TITLE
Added MonitoringSignificantLocationChanges API

### DIFF
--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -126,7 +126,13 @@ extension LocationManager {
         .fireAndForget { dependencies[id]?.manager.startUpdatingLocation() }
       }
     #endif
-
+    
+    #if os(iOS) || targetEnvironment(macCatalyst)
+      manager.startMonitoringSignificantLocationChanges = { id in
+        .fireAndForget { dependencies[id]?.manager.startMonitoringSignificantLocationChanges() }
+      }
+    #endif
+    
     #if os(iOS) || targetEnvironment(macCatalyst)
       manager.stopMonitoringVisits = { id in
         .fireAndForget { dependencies[id]?.manager.stopMonitoringVisits() }
@@ -148,6 +154,12 @@ extension LocationManager {
     manager.stopUpdatingLocation = { id in
       .fireAndForget { dependencies[id]?.manager.stopUpdatingLocation() }
     }
+    
+    #if os(iOS) || targetEnvironment(macCatalyst)
+      manager.stopMonitoringSignificantLocationChanges = { id in
+        .fireAndForget { dependencies[id]?.manager.stopMonitoringSignificantLocationChanges() }
+      }
+    #endif
 
     return manager
   }()


### PR DESCRIPTION
Add Core Location API's for starting and stopping monitoring significant location changes.

- https://developer.apple.com/documentation/corelocation/cllocationmanager/1423531-startmonitoringsignificantlocati
- https://developer.apple.com/documentation/corelocation/cllocationmanager/1423679-stopmonitoringsignificantlocatio