### PR TITLE
Region monitoring

### DIFF
--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -127,6 +127,25 @@ extension LocationManager {
     }
 
     #if os(iOS) || targetEnvironment(macCatalyst)
+    manager.monitoredRegions = { id -> Set<Region> in
+        let regions = dependencies[id]?.manager.monitoredRegions.map { Region(rawValue: $0) } ?? []
+        return Set(regions)
+    }
+    #endif
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    manager.maximumRegionMonitoringDistance = { id -> CLLocationDistance in
+        dependencies[id]?.manager.maximumRegionMonitoringDistance ?? -1
+    }
+    #endif
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+      manager.startMonitoringForRegion = { id, region in
+        .fireAndForget { dependencies[id]?.manager.startMonitoring(for: region.rawValue!) }
+      }
+    #endif
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
       manager.startMonitoringVisits = { id in
         .fireAndForget { dependencies[id]?.manager.startMonitoringVisits() }
       }
@@ -141,6 +160,12 @@ extension LocationManager {
     #if os(iOS) || targetEnvironment(macCatalyst)
       manager.startMonitoringSignificantLocationChanges = { id in
         .fireAndForget { dependencies[id]?.manager.startMonitoringSignificantLocationChanges() }
+      }
+    #endif
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+      manager.stopMonitoringForRegion = { id, region in
+        .fireAndForget { dependencies[id]?.manager.stopMonitoring(for: region.rawValue!) }
       }
     #endif
 


### PR DESCRIPTION
Implementing missing bridge for `LocationManager` to support region monitoring.

We can discuss unwrapping optionals and default values.