### PR TITLE
Do not nil out rawValue if created from CLVisit

### DIFF
--- a/Sources/ComposableCoreLocation/Models/Visit.swift
+++ b/Sources/ComposableCoreLocation/Models/Visit.swift
@@ -15,7 +15,7 @@ public struct Visit: Hashable {
   public var horizontalAccuracy: CLLocationAccuracy
 
   init(visit: CLVisit) {
-    self.rawValue = nil
+    self.rawValue = visit
 
     self.arrivalDate = visit.arrivalDate
     self.coordinate = visit.coordinate


### PR DESCRIPTION
Small, but annoying one-line mistake corrected.