### PR TITLE
Adds support for requesting temporary full accuracy authorization

### DIFF
--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -304,11 +304,9 @@ public struct LocationManager {
     _unimplemented("requestWhenInUseAuthorization")
   }
     
-  #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
-    var requestTemporaryFullAccuracyAuthorization: (AnyHashable, String) -> Effect<Never, Never> = { _, _  in
-      _unimplemented("requestTemporaryFullAccuracyAuthorization")
-    }
-  #endif
+  var requestTemporaryFullAccuracyAuthorization: (AnyHashable, String) -> Effect<Never, Never> = { _, _  in
+    _unimplemented("requestTemporaryFullAccuracyAuthorization")
+  }
 
   var set: (AnyHashable, Properties) -> Effect<Never, Never> = { _, _ in _unimplemented("set") }
 

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -303,6 +303,12 @@ public struct LocationManager {
   var requestWhenInUseAuthorization: (AnyHashable) -> Effect<Never, Never> = { _ in
     _unimplemented("requestWhenInUseAuthorization")
   }
+    
+  #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
+    var requestTemporaryFullAccuracyAuthorization: (AnyHashable, String) -> Effect<Never, Never> = { _, _  in
+      _unimplemented("requestTemporaryFullAccuracyAuthorization")
+    }
+  #endif
 
   var set: (AnyHashable, Properties) -> Effect<Never, Never> = { _, _ in _unimplemented("set") }
 
@@ -424,6 +430,11 @@ public struct LocationManager {
   @available(macOS, unavailable)
   public func requestWhenInUseAuthorization(id: AnyHashable) -> Effect<Never, Never> {
     self.requestWhenInUseAuthorization(id)
+  }
+    
+  @available(iOS 14.0, macCatalyst 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+  public func requestTemporaryFullAccuracyAuthorization(id: AnyHashable, purposeKey: String) -> Effect<Never, Never> {
+    self.requestTemporaryFullAccuracyAuthorization(id, purposeKey)
   }
 
   /// Updates the given properties of a uniquely identified `CLLocationManager`.

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -74,6 +74,15 @@ extension LocationManager {
         .fireAndForget { dependencies[id]?.manager.requestWhenInUseAuthorization() }
       }
     #endif
+    
+    manager.requestTemporaryFullAccuracyAuthorization = { id, purposeKey in
+      #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
+        if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
+          return .fireAndForget { dependencies[id]?.manager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey) }
+        }
+      #endif
+      return .none
+    }
 
     manager.set = { id, properties in
       .fireAndForget {

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -72,13 +72,18 @@ extension LocationManager {
     #if os(iOS) || os(tvOS) || os(watchOS) || targetEnvironment(macCatalyst)
       manager.requestWhenInUseAuthorization = { id in
         .fireAndForget { dependencies[id]?.manager.requestWhenInUseAuthorization() }
-      }
+    }
     #endif
     
     if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
-      manager.requestTemporaryFullAccuracyAuthorization = { id, purposeKey in
-        .fireAndForget { dependencies[id]?.manager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey) }
-      }
+      #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
+        manager.requestTemporaryFullAccuracyAuthorization = { id, purposeKey in
+          .fireAndForget {
+            dependencies[id]?.manager
+              .requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey)
+          }
+        }
+      #endif
     }
 
     manager.set = { id, properties in

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -75,13 +75,10 @@ extension LocationManager {
       }
     #endif
     
-    manager.requestTemporaryFullAccuracyAuthorization = { id, purposeKey in
-      #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
-        if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
-          return .fireAndForget { dependencies[id]?.manager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey) }
-        }
-      #endif
-      return .none
+    if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
+      manager.requestTemporaryFullAccuracyAuthorization = { id, purposeKey in
+        .fireAndForget { dependencies[id]?.manager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey) }
+      }
     }
 
     manager.set = { id, properties in

--- a/Sources/ComposableCoreLocation/Mock.swift
+++ b/Sources/ComposableCoreLocation/Mock.swift
@@ -73,6 +73,9 @@
       requestWhenInUseAuthorization: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
         _unimplemented("requestWhenInUseAuthorization")
       },
+      requestTemporaryFullAccuracyAuthorization: @escaping (AnyHashable, String) -> Effect<Never, Never> = { _, _ in
+        _unimplemented("requestTemporaryFullAccuracyAuthorization")
+      },
       set: @escaping (_ id: AnyHashable, _ properties: Properties) -> Effect<Never, Never> = {
         _, _ in _unimplemented("set")
       },
@@ -126,6 +129,7 @@
         requestAlwaysAuthorization: requestAlwaysAuthorization,
         requestLocation: requestLocation,
         requestWhenInUseAuthorization: requestWhenInUseAuthorization,
+        requestTemporaryFullAccuracyAuthorization: requestTemporaryFullAccuracyAuthorization,
         set: set,
         significantLocationChangeMonitoringAvailable: significantLocationChangeMonitoringAvailable,
         startMonitoringForRegion: startMonitoringForRegion,


### PR DESCRIPTION
Adds a new requestTemporaryFullAccuracyAuthorization function on supported platforms. This allows promoting a user for temporary access to their precise location after previously granting approximate location only.