### PR TITLE
Pin TCA dependency to rev with `Effect.failing` available in release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.25.0")
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .revision("86bcd08"))
   ],
   targets: [
     .target(


### PR DESCRIPTION
Once and for all resolves #14 i.e. allows for this package to build in release configuration.