### PR TITLE
Return completion data when requesting temporary full accuracy permissions

### DIFF
--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -297,7 +297,7 @@ public struct LocationManager {
 
   public var requestTemporaryFullAccuracyAuthorization:
     (String)
-      -> Effect<Never, Never>
+      -> Effect<CLAccuracyAuthorization, Error>
 
   public var set: (Properties) -> Effect<Never, Never>
 

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -295,9 +295,7 @@ public struct LocationManager {
   @available(macOS, unavailable)
   public var requestWhenInUseAuthorization: () -> Effect<Never, Never>
 
-  public var requestTemporaryFullAccuracyAuthorization:
-    (String)
-      -> Effect<AccuracyAuthorization?, Error>
+  public var requestTemporaryFullAccuracyAuthorization: (String) -> Effect<Never, Error>
 
   public var set: (Properties) -> Effect<Never, Never>
 

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -297,7 +297,7 @@ public struct LocationManager {
 
   public var requestTemporaryFullAccuracyAuthorization:
     (String)
-      -> Effect<CLAccuracyAuthorization, Error>
+      -> Effect<AccuracyAuthorization?, Error>
 
   public var set: (Properties) -> Effect<Never, Never>
 

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -110,7 +110,8 @@ extension LocationManager {
                       if let error = error {
                           callback(.failure(LocationManager.Error(error)))
                       } else {
-                          callback(.success(manager.accuracyAuthorization))
+                          let accuracy = AccuracyAuthorization(manager.accuracyAuthorization)
+                          callback(.success(accuracy))
                       }
                   }
               }

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -103,14 +103,19 @@ extension LocationManager {
         }
       },
       requestTemporaryFullAccuracyAuthorization: { purposeKey in
-        .fireAndForget {
-          #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
-            if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
-              manager
-                .requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey)
-            }
-          #endif
-        }
+          Effect.future { callback in
+            #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
+              if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
+                  manager.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey) { error in
+                      if let error = error {
+                          callback(.failure(LocationManager.Error(error)))
+                      } else {
+                          callback(.success(manager.accuracyAuthorization))
+                      }
+                  }
+              }
+            #endif
+          }
       },
       set: { properties in
         .fireAndForget {

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -103,7 +103,7 @@ extension LocationManager {
         }
       },
       requestTemporaryFullAccuracyAuthorization: { purposeKey in
-        Effect.run { subscriber in
+        .run { subscriber in
           #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
             if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
               manager.requestTemporaryFullAccuracyAuthorization(


### PR DESCRIPTION
Returns the updated accuracyAuthorization or the completion closure's error as a future when requesting temporary full access authorization.