### PR TITLE
Replace deprecated API - `CLLocationManager.authorizationStatus()`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "composable-core-location",
   platforms: [
-    .iOS(.v13),
+    .iOS(.v14),
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "composable-core-location",
   platforms: [
-    .iOS(.v14),
+    .iOS(.v13),
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -39,14 +39,14 @@ extension LocationManager {
         #endif
         return nil
       },
-	  authorizationStatus: {
+      authorizationStatus: {
         #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
           if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
             return manager.authorizationStatus
           }
         #endif
         return CLLocationManager.authorizationStatus()
-	  },
+      },
       delegate: { delegate },
       dismissHeadingCalibrationDisplay: {
         .fireAndForget {

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -39,7 +39,14 @@ extension LocationManager {
         #endif
         return nil
       },
-      authorizationStatus: CLLocationManager.authorizationStatus,
+	  authorizationStatus: {
+        #if (compiler(>=5.3) && !(os(macOS) || targetEnvironment(macCatalyst))) || compiler(>=5.3.1)
+          if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, macCatalyst 14.0, *) {
+            return manager.authorizationStatus
+          }
+        #endif
+        return CLLocationManager.authorizationStatus()
+	  },
       delegate: { delegate },
       dismissHeadingCalibrationDisplay: {
         .fireAndForget {


### PR DESCRIPTION
Calling `CLLocationManager.authorizationStatus()` is deprecated in iOS 14, tvOS 14, watchOS 7, and macOS 11.
Instead, this has been replaced with a call to the `authorizationStatus` instance variable.

(I copied the compiler guard from other `#if available(iOS 14...` instances, as I assume there's some Xcode bug?)