### PR TITLE
Update library to work with TCA 0.57

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {
           "branch": null,
-          "revision": "4cf088c29a20f52be0f2ca54992b492c54e0076b",
-          "version": "0.5.3"
+          "revision": "ec62f32d21584214a4b27c8cee2b2ad70ab2c38a",
+          "version": "0.11.0"
         }
       },
       {
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
         "state": {
           "branch": null,
-          "revision": "d226d167bd4a68b51e352af5655c92bce8ee0463",
-          "version": "0.7.0"
+          "revision": "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
+          "version": "0.14.1"
+        }
+      },
+      {
+        "package": "swift-clocks",
+        "repositoryURL": "https://github.com/pointfreeco/swift-clocks",
+        "state": {
+          "branch": null,
+          "revision": "0fbaebfc013715dab44d715a4d350ba37f297e4d",
+          "version": "0.4.0"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "2d33a0ea89c961dcb2b3da2157963d9c0370347e",
-          "version": "1.0.1"
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
         }
       },
       {
@@ -33,8 +42,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-composable-architecture",
         "state": {
           "branch": null,
-          "revision": "599a2398adaaa7a4e3f5420cde7728c39e33677e",
-          "version": "0.28.1"
+          "revision": "db2a55fd89ee5d88aa18a2325ba15654e619dc45",
+          "version": "0.57.0"
+        }
+      },
+      {
+        "package": "swift-concurrency-extras",
+        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
+        "state": {
+          "branch": null,
+          "revision": "479750bd98fac2e813fffcf2af0728b5b0085795",
+          "version": "0.1.1"
         }
       },
       {
@@ -42,8 +60,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
         "state": {
           "branch": null,
-          "revision": "21f8fdbb3226e5e28a1a2fffac3e0f3deec34bf0",
-          "version": "0.2.1"
+          "revision": "4a87bb75be70c983a9548597e8783236feb3401e",
+          "version": "0.11.1"
+        }
+      },
+      {
+        "package": "swift-dependencies",
+        "repositoryURL": "https://github.com/pointfreeco/swift-dependencies",
+        "state": {
+          "branch": null,
+          "revision": "16fd42ae04c6e7f74a6a86395d04722c641cccee",
+          "version": "0.6.0"
         }
       },
       {
@@ -51,8 +78,17 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
         "state": {
           "branch": null,
-          "revision": "f76e7d3fe4265ee09216044ec3780d74f546ca82",
-          "version": "0.3.1"
+          "revision": "d01446a78fb768adc9a78cbb6df07767c8ccfc29",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "swiftui-navigation",
+        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
+        "state": {
+          "branch": null,
+          "revision": "2aa885e719087ee19df251c08a5980ad3e787f12",
+          "version": "0.8.0"
         }
       },
       {
@@ -60,8 +96,8 @@
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {
           "branch": null,
-          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
-          "version": "0.2.1"
+          "revision": "50843cbb8551db836adec2290bb4bc6bac5c1865",
+          "version": "0.9.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/pointfreeco/swift-composable-architecture",
-      .upToNextMajor(from: "0.27.1"))
+      .upToNextMajor(from: "0.43.0"))
   ],
   targets: [
     .target(

--- a/Sources/ComposableCoreLocation/Failing.swift
+++ b/Sources/ComposableCoreLocation/Failing.swift
@@ -38,72 +38,32 @@ extension LocationManager {
   /// }
   /// ```
   public static let failing = Self(
-    accuracyAuthorization: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.accuracyAuthorization'")
-      return nil
-    },
-    authorizationStatus: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.authorizationStatus'")
-      return .notDetermined
-    },
-    delegate: { .failing("LocationManager.delegate") },
-    dismissHeadingCalibrationDisplay: {
-      .failing("LocationManager.dismissHeadingCalibrationDisplay")
-    },
-    heading: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.heading'")
-      return nil
-    },
-    headingAvailable: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.headingAvailable'")
-      return false
-    },
-    isRangingAvailable: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.isRangingAvailable'")
-      return false
-    },
-    location: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.location'")
-      return nil
-    },
-    locationServicesEnabled: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.locationServicesEnabled'")
-      return false
-    },
-    maximumRegionMonitoringDistance: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.maximumRegionMonitoringDistance'")
-      return CLLocationDistanceMax
-    },
-    monitoredRegions: {
-      XCTFail("A failing endpoint was accessed: 'LocationManager.monitoredRegions'")
-      return []
-    },
-    requestAlwaysAuthorization: { .failing("LocationManager.requestAlwaysAuthorization") },
-    requestLocation: { .failing("LocationManager.requestLocation") },
-    requestWhenInUseAuthorization: {
-      .failing("LocationManager.requestWhenInUseAuthorization")
-    },
-    requestTemporaryFullAccuracyAuthorization: { _ in
-      .failing("LocationManager.requestTemporaryFullAccuracyAuthorization")
-    },
-    set: { _ in .failing("LocationManager.set") },
-    significantLocationChangeMonitoringAvailable: {
-      XCTFail()
-      return false
-    },
-    startMonitoringForRegion: { _ in .failing("LocationManager.startMonitoringForRegion") },
-    startMonitoringSignificantLocationChanges: {
-      .failing("LocationManager.startMonitoringSignificantLocationChanges")
-    },
-    startMonitoringVisits: { .failing("LocationManager.startMonitoringVisits") },
-    startUpdatingHeading: { .failing("LocationManager.startUpdatingHeading") },
-    startUpdatingLocation: { .failing("LocationManager.startUpdatingLocation") },
-    stopMonitoringForRegion: { _ in .failing("LocationManager.stopMonitoringForRegion") },
-    stopMonitoringSignificantLocationChanges: {
-      .failing("LocationManager.stopMonitoringSignificantLocationChanges")
-    },
-    stopMonitoringVisits: { .failing("LocationManager.stopMonitoringVisits") },
-    stopUpdatingHeading: { .failing("LocationManager.stopUpdatingHeading") },
-    stopUpdatingLocation: { .failing("LocationManager.stopUpdatingLocation") }
+    accuracyAuthorization: XCTUnimplemented("LocationManager.accuracyAuthorization"),
+    authorizationStatus: XCTUnimplemented("A failing endpoint was accessed: 'LocationManager.authorizationStatus'"),
+    delegate: XCTUnimplemented("LocationManager.delegate"),
+    dismissHeadingCalibrationDisplay: XCTUnimplemented("LocationManager.dismissHeadingCalibrationDisplay"),
+    heading: XCTUnimplemented("A failing endpoint was accessed: 'LocationManager.heading'"),
+    headingAvailable: XCTUnimplemented("LocationManager.headingAvailable"),
+    isRangingAvailable: XCTUnimplemented("LocationManager.isRangingAvailable"),
+    location: XCTUnimplemented("LocationManager.location"),
+    locationServicesEnabled: XCTUnimplemented("LocationManager.locationServicesEnabled"),
+    maximumRegionMonitoringDistance: XCTUnimplemented("LocationManager.maximumRegionMonitoringDistance"),
+    monitoredRegions: XCTUnimplemented("LocationManager.monitoredRegions"),
+    requestAlwaysAuthorization: XCTUnimplemented("LocationManager.requestAlwaysAuthorization"),
+    requestLocation: XCTUnimplemented("LocationManager.requestLocation"),
+    requestWhenInUseAuthorization: XCTUnimplemented("LocationManager.requestWhenInUseAuthorization"),
+    requestTemporaryFullAccuracyAuthorization: XCTUnimplemented("LocationManager.requestTemporaryFullAccuracyAuthorization"),
+    set: XCTUnimplemented("LocationManager.set"),
+    significantLocationChangeMonitoringAvailable: XCTUnimplemented("LocationManager.significantLocationChangeMonitoringAvailable"),
+    startMonitoringForRegion: XCTUnimplemented("LocationManager.startMonitoringForRegion"),
+    startMonitoringSignificantLocationChanges: XCTUnimplemented("LocationManager.startMonitoringSignificantLocationChanges"),
+    startMonitoringVisits: XCTUnimplemented("LocationManager.startMonitoringVisits"),
+    startUpdatingHeading: XCTUnimplemented("LocationManager.startUpdatingHeading"),
+    startUpdatingLocation: XCTUnimplemented("LocationManager.startUpdatingLocation"),
+    stopMonitoringForRegion: XCTUnimplemented("LocationManager.stopMonitoringForRegion"),
+    stopMonitoringSignificantLocationChanges: XCTUnimplemented("LocationManager.stopMonitoringSignificantLocationChanges"),
+    stopMonitoringVisits: XCTUnimplemented("LocationManager.stopMonitoringVisits"),
+    stopUpdatingHeading: XCTUnimplemented("LocationManager.stopUpdatingHeading"),
+    stopUpdatingLocation: XCTUnimplemented("LocationManager.stopUpdatingLocation")
   )
 }

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -257,11 +257,11 @@ public struct LocationManager {
 
   public var authorizationStatus: () -> CLAuthorizationStatus
 
-  public var delegate: () -> Effect<Action, Never>
+  public var delegate: () -> EffectPublisher<Action, Never>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
-  public var dismissHeadingCalibrationDisplay: () -> Effect<Never, Never>
+  public var dismissHeadingCalibrationDisplay: () -> EffectPublisher<Never, Never>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
@@ -288,15 +288,15 @@ public struct LocationManager {
   public var monitoredRegions: () -> Set<Region>
 
   @available(tvOS, unavailable)
-  public var requestAlwaysAuthorization: () -> Effect<Never, Never>
+  public var requestAlwaysAuthorization: () -> EffectPublisher<Never, Never>
 
-  public var requestLocation: () -> Effect<Never, Never>
+  public var requestLocation: () -> EffectPublisher<Never, Never>
 
-  public var requestWhenInUseAuthorization: () -> Effect<Never, Never>
+  public var requestWhenInUseAuthorization: () -> EffectPublisher<Never, Never>
 
-  public var requestTemporaryFullAccuracyAuthorization: (String) -> Effect<Never, Error>
+  public var requestTemporaryFullAccuracyAuthorization: (String) -> EffectPublisher<Never, Error>
 
-  public var set: (Properties) -> Effect<Never, Never>
+  public var set: (Properties) -> EffectPublisher<Never, Never>
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
@@ -304,42 +304,42 @@ public struct LocationManager {
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var startMonitoringForRegion: (Region) -> Effect<Never, Never>
+  public var startMonitoringForRegion: (Region) -> EffectPublisher<Never, Never>
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var startMonitoringSignificantLocationChanges: () -> Effect<Never, Never>
+  public var startMonitoringSignificantLocationChanges: () -> EffectPublisher<Never, Never>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var startMonitoringVisits: () -> Effect<Never, Never>
+  public var startMonitoringVisits: () -> EffectPublisher<Never, Never>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
-  public var startUpdatingHeading: () -> Effect<Never, Never>
+  public var startUpdatingHeading: () -> EffectPublisher<Never, Never>
 
   @available(tvOS, unavailable)
-  public var startUpdatingLocation: () -> Effect<Never, Never>
-
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  public var stopMonitoringForRegion: (Region) -> Effect<Never, Never>
+  public var startUpdatingLocation: () -> EffectPublisher<Never, Never>
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var stopMonitoringSignificantLocationChanges: () -> Effect<Never, Never>
+  public var stopMonitoringForRegion: (Region) -> EffectPublisher<Never, Never>
+
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  public var stopMonitoringSignificantLocationChanges: () -> EffectPublisher<Never, Never>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var stopMonitoringVisits: () -> Effect<Never, Never>
+  public var stopMonitoringVisits: () -> EffectPublisher<Never, Never>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
-  public var stopUpdatingHeading: () -> Effect<Never, Never>
+  public var stopUpdatingHeading: () -> EffectPublisher<Never, Never>
 
-  public var stopUpdatingLocation: () -> Effect<Never, Never>
+  public var stopUpdatingLocation: () -> EffectPublisher<Never, Never>
 
   /// Updates the given properties of a uniquely identified `CLLocationManager`.
   @available(macOS, unavailable)
@@ -354,7 +354,7 @@ public struct LocationManager {
     headingOrientation: CLDeviceOrientation? = nil,
     pausesLocationUpdatesAutomatically: Bool? = nil,
     showsBackgroundLocationIndicator: Bool? = nil
-  ) -> Effect<Never, Never> {
+  ) -> EffectPublisher<Never, Never> {
     self.set(
       Properties(
         activityType: activityType,

--- a/Sources/ComposableCoreLocation/Internal/Deprecations.swift
+++ b/Sources/ComposableCoreLocation/Internal/Deprecations.swift
@@ -7,7 +7,7 @@
       message:
         "Use 'Effect.cancellable' and 'Effect.cancel' to manage the lifecycle of 'LocationManager.delegate'"
     )
-    public func create(id: AnyHashable) -> Effect<Action, Never> {
+    public func create(id: AnyHashable) -> EffectPublisher<Action, Never> {
       self.delegate().cancellable(id: id)
     }
 
@@ -16,7 +16,7 @@
       message:
         "Use 'Effect.cancellable' and 'Effect.cancel' to manage the lifecycle of 'LocationManager.delegate'"
     )
-    public func destroy(id: AnyHashable) -> Effect<Never, Never> {
+    public func destroy(id: AnyHashable) -> EffectPublisher<Never, Never> {
       .cancel(id: id)
     }
 
@@ -28,11 +28,11 @@
       authorizationStatus: @escaping () -> CLAuthorizationStatus = {
         _unimplemented("authorizationStatus")
       },
-      create: @escaping (_ id: AnyHashable) -> Effect<Action, Never> = { _ in
+      create: @escaping (_ id: AnyHashable) -> EffectPublisher<Action, Never> = { _ in
         _unimplemented("create")
       },
-      destroy: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in _unimplemented("destroy") },
-      dismissHeadingCalibrationDisplay: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      destroy: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in _unimplemented("destroy") },
+      dismissHeadingCalibrationDisplay: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("dismissHeadingCalibrationDisplay")
       },
       heading: @escaping (AnyHashable) -> Heading? = { _ in _unimplemented("heading") },
@@ -46,54 +46,54 @@
       monitoredRegions: @escaping (AnyHashable) -> Set<Region> = { _ in
         _unimplemented("monitoredRegions")
       },
-      requestAlwaysAuthorization: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      requestAlwaysAuthorization: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("requestAlwaysAuthorization")
       },
-      requestLocation: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      requestLocation: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("requestLocation")
       },
-      requestWhenInUseAuthorization: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      requestWhenInUseAuthorization: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("requestWhenInUseAuthorization")
       },
-      requestTemporaryFullAccuracyAuthorization: @escaping (AnyHashable, String) -> Effect<
+      requestTemporaryFullAccuracyAuthorization: @escaping (AnyHashable, String) -> EffectPublisher<
         Never, Never
       > = { _, _ in
         _unimplemented("requestTemporaryFullAccuracyAuthorization")
       },
-      set: @escaping (_ id: AnyHashable, _ properties: Properties) -> Effect<Never, Never> = {
+      set: @escaping (_ id: AnyHashable, _ properties: Properties) -> EffectPublisher<Never, Never> = {
         _, _ in _unimplemented("set")
       },
       significantLocationChangeMonitoringAvailable: @escaping () -> Bool = {
         _unimplemented("significantLocationChangeMonitoringAvailable")
       },
-      startMonitoringSignificantLocationChanges: @escaping (AnyHashable) -> Effect<Never, Never> = {
+      startMonitoringSignificantLocationChanges: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = {
         _ in _unimplemented("startMonitoringSignificantLocationChanges")
       },
-      startMonitoringForRegion: @escaping (AnyHashable, Region) -> Effect<Never, Never> = { _, _ in
+      startMonitoringForRegion: @escaping (AnyHashable, Region) -> EffectPublisher<Never, Never> = { _, _ in
         _unimplemented("startMonitoringForRegion")
       },
-      startMonitoringVisits: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      startMonitoringVisits: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("startMonitoringVisits")
       },
-      startUpdatingLocation: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      startUpdatingLocation: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("startUpdatingLocation")
       },
-      stopMonitoringSignificantLocationChanges: @escaping (AnyHashable) -> Effect<Never, Never> = {
+      stopMonitoringSignificantLocationChanges: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = {
         _ in _unimplemented("stopMonitoringSignificantLocationChanges")
       },
-      stopMonitoringForRegion: @escaping (AnyHashable, Region) -> Effect<Never, Never> = { _, _ in
+      stopMonitoringForRegion: @escaping (AnyHashable, Region) -> EffectPublisher<Never, Never> = { _, _ in
         _unimplemented("stopMonitoringForRegion")
       },
-      stopMonitoringVisits: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      stopMonitoringVisits: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("stopMonitoringVisits")
       },
-      startUpdatingHeading: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      startUpdatingHeading: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("startUpdatingHeading")
       },
-      stopUpdatingHeading: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      stopUpdatingHeading: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("stopUpdatingHeading")
       },
-      stopUpdatingLocation: @escaping (AnyHashable) -> Effect<Never, Never> = { _ in
+      stopUpdatingLocation: @escaping (AnyHashable) -> EffectPublisher<Never, Never> = { _ in
         _unimplemented("stopUpdatingLocation")
       }
     ) -> Self {

--- a/Sources/ComposableCoreLocation/Live.swift
+++ b/Sources/ComposableCoreLocation/Live.swift
@@ -19,7 +19,7 @@ extension LocationManager {
   public static var live: Self {
     let manager = CLLocationManager()
 
-    let delegate = Effect<Action, Never>.run { subscriber in
+    let delegate = EffectPublisher<Action, Never>.run { subscriber in
       let delegate = LocationManagerDelegate(subscriber)
       manager.delegate = delegate
 
@@ -247,9 +247,9 @@ extension LocationManager {
 }
 
 private class LocationManagerDelegate: NSObject, CLLocationManagerDelegate {
-  let subscriber: Effect<LocationManager.Action, Never>.Subscriber
+  let subscriber: EffectPublisher<LocationManager.Action, Never>.Subscriber
 
-  init(_ subscriber: Effect<LocationManager.Action, Never>.Subscriber) {
+  init(_ subscriber: EffectPublisher<LocationManager.Action, Never>.Subscriber) {
     self.subscriber = subscriber
   }
 


### PR DESCRIPTION
This change updates all references to `Effect` to `EffectPublisher`, and cleans up a few warnings with `LocationManager.failing` by using the more recent `XCTUnimplemented` function, though it doesn't update the signature to use a function at this time. This should let the library compile for versions of tca >= 0.43 (when `EffectPublisher` was introduced), including 0.57 which broke the old 2-generic clause `Effect`.

I've confirmed that tests pass on tca 0.43 and 0.57, but not on versions in between.
